### PR TITLE
3d space filling

### DIFF
--- a/src/GilbertCurves.jl
+++ b/src/GilbertCurves.jl
@@ -10,7 +10,7 @@ space-filling, starting at `CartesianIndex(1,1)`.  It will end at
 `CartesianIndex(dims[1],1)` if `majdim==1`, or `CartesianIndex(1,dims[2])` if `majdim==2`
 (or the closest feasible point).
 """
-gilbertindices(dims::Tuple{Int,Int}; kwargs...) =
+gilbertindices(dims::Tuple; kwargs...) =
     gilbertorder(CartesianIndices(dims); kwargs...)
 
 
@@ -30,6 +30,19 @@ function gilbertorder(mat::AbstractMatrix{T}; majdim=size(mat,1) >= size(mat,2) 
     end
 end
 
+# 3D ordering
+function gilbertorder(mat::AbstractArray{T, 3}; majdim=findmax(size(mat))) where {T}
+    list = sizehint!(T[], length(mat))
+    if majdim == 1
+        append_gilbert!(list, mat)
+    elseif majdim == 2
+        append_gilbert!(list, permutedims(mat,(2,1,3)))
+    else
+        append_gilbert!(list, permutedims(mat,(3,2,1)))
+    end
+end
+
+# 2D ordering
 function append_gilbert!(list, mat::AbstractMatrix)
     # 1 |*    |
     #   | )   |
@@ -77,13 +90,65 @@ function append_gilbert!(list, mat::AbstractMatrix)
     end
 end
 
+# 3D ordering
+function append_gilbert!(list, mat::AbstractArray{T, 3}) where {T}
+
+    a,b,c = size(mat)
+
+    if sum((a, b, c) .== 1) > 1
+        # single in one dimension
+        append!(list, mat)
+    # wide case, split in width only
+    elseif (2a > 3b) && (2a > 3c)
+        a2 = div(a,2)
+        if isodd(a2) && a > 2
+            a2 += 1
+        end
+        append_gilbert!(list, mat[1:a2,:,:])
+        append_gilbert!(list, mat[a2+1:a,:,:])
+    # do not split in depth
+    elseif 3b > 4c
+        a2 = div(a,2)
+        b2 = div(b,2)
+        if isodd(b2) && b > 2
+            b2 += 1
+        end
+        append_gilbert!(list, permutedims(mat[1:a2,1:b2,:],(2,3,1)))
+        append_gilbert!(list, mat[:,b2+1:b,:])
+        append_gilbert!(list, permutedims(mat[a:-1:a2+1,b2:-1:1,:],(2,3,1)))
+    # do not split in height
+    elseif 3c > 4b
+        a2 = div(a,2)
+        c2 = div(c,2)
+        if isodd(c2) && c > 2
+            c2 += 1
+        end
+        append_gilbert!(list, permutedims(mat[1:a2,:,1:c2],(3,1,2)))
+        append_gilbert!(list, mat[:,:,c2+1:c])
+        append_gilbert!(list, permutedims(mat[a:-1:a2+1,:,c2:-1:1],(3,1,2)))
+    # regular case, split in all w/h/d 
+    else
+        a2 = div(a,2)
+        b2 = div(b,2)
+        c2 = div(c,2)
+        if isodd(c2) && c > 2
+            c2 += 1
+        end
+        append_gilbert!(list, permutedims(mat[1:a2,1:b2,1:c2],(2,3,1))) 
+        append_gilbert!(list, permutedims(mat[1:a2,b2+1:b,:],(3,1,2))) 
+        append_gilbert!(list, mat[:,b2:-1:1,c:-1:c2+1])
+        append_gilbert!(list, permutedims(mat[a:-1:a2+1,b2+1:b,c:-1:1],(3,1,2)))
+        append_gilbert!(list, permutedims(mat[a:-1:a2+1,b2:-1:1,1:c2],(2,3,1)))
+    end
+end
+
 """
     linearindices(list::Vector{CartesianIndex{2}})
 
-Construct an integer matrix `M` containing the integers `1:length(list)` such that
+Construct an integer Array `M` containing the integers `1:length(list)` such that
 `M[list[i]] == i`.
 """
-function linearindices(list::Vector{CartesianIndex{2}})
+function linearindices(list::Vector{CartesianIndex{N}}) where {N}
     cmax = maximum(list)
     L = zeros(Int,cmax.I)
     for (i,c) in enumerate(list)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,3 +34,13 @@ using Test
     @test !any(iszero, L)
     @test sum(L) == sum(1:m*n)
 end
+
+@testset "size $m,$n,$p" for m = 1:20, n = 1:20, p = 1:20
+    list = gilbertindices((m,n,p))
+    @test length(list)         == m*n*p
+    @test length(unique(list)) == m*n*p
+    @test list[1]              == CartesianIndex(1,1,1)
+
+    L = GilbertCurves.linearindices(list)
+    @test !any(iszero, L)
+end


### PR DESCRIPTION
The aim of this PR is to generate a 3D space-filling curve to improve memory locality and global memory fetches on GPU.

A way to do this is to create a set of rules that allow you to convert a 3D index to a 1D index ordered following the space-filling curve.

Unfortunately, this index conversion must be done on the fly and cannot rely on stored memory, otherwise, we just shift the problem from fetching the value to fetching the index (I am not still sure if it will be performant)
